### PR TITLE
Make Calamari pages refer to full nodes

### DIFF
--- a/docs/calamari/get-calamari.md
+++ b/docs/calamari/get-calamari.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 ## Choose your installation variant
 
-With it you will be able to join the Calamari dev [testnet](https://telemetry.manta.systems/#/Calamari-Parachain%20Development)
+With it you will be able to join the Calamari dev [network](https://telemetry.manta.systems/#/Calamari-Parachain%20Development)
 
 ### Option 1: Build From Source
 

--- a/docs/calamari/get-calamari.md
+++ b/docs/calamari/get-calamari.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 ## Choose your installation variant
 
-With it you will be able to join the Calamari dev network https://telemetry.manta.systems/#/Calamari-Parachain%20Development
+With it you will be able to join the Calamari dev [testnet](https://telemetry.manta.systems/#/Calamari-Parachain%20Development)
 
 ### Option 1: Build From Source
 
@@ -111,7 +111,7 @@ Then you will ned to run this command to generate the file:
 
 ### Option 2: Use a Binary Release
 
-1. Get the binary ---> https://github.com/Manta-Network/Manta/releases/download/v3.0.0-b63b2d2/calamari-pc
-2. Get the relay chain chain-spec file ----> https://github.com/Manta-Network/Manta/releases/download/v3.0.0-b63b2d2/rococo.json
+1. Get the [binary](https://github.com/Manta-Network/Manta/releases/download/v3.0.0-b63b2d2/calamari-pc)
+2. Get the relay chain chain-spec [file](https://github.com/Manta-Network/Manta/releases/download/v3.0.0-b63b2d2/rococo.json)
 
 Take note of the locations of these files, you will need them in the next section.

--- a/docs/calamari/join-network.md
+++ b/docs/calamari/join-network.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Join the network
 
-Specifically the Calamari development test-net ----> https://telemetry.manta.systems/#/Calamari-Parachain%20Development
+Specifically the Calamari development [testnet](https://telemetry.manta.systems/#/Calamari-Parachain%20Development)
 
 ## As a full node
 
@@ -38,7 +38,7 @@ ${para_chain_binary} \
   
   ``sudo chmod +x ${para_chain_binary}``
 
-Check https://telemetry.manta.systems/#list/Calamari-Parachain%20Development to see if your node is in the list.
+Check [here](https://telemetry.manta.systems/#list/Calamari-Parachain%20Development) to see if your node is in the list.
 If you want to explore with the Polkadot.js front-end, replace this string ``wss://${node_name}`` with one of the node names in the network.
 With that you can connect to it and try to communicate with the block chain with extrinsics, or explore it with the block explorer.
 

--- a/docs/calamari/join-network.md
+++ b/docs/calamari/join-network.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 Specifically the Calamari development test-net ----> https://telemetry.manta.systems/#/Calamari-Parachain%20Development
 
-## As a collator
+## As a full node
 
 #### specific to this node
   - ``my_node_name=my-awesome-manta-node``
@@ -21,7 +21,6 @@ Specifically the Calamari development test-net ----> https://telemetry.manta.sys
 ```bash
 
 ${para_chain_binary} \
-  --collator \
   --name ${my_node_name} \
   --base-path ${my_db_path} \
   --chain calamari-dev \
@@ -47,4 +46,5 @@ Take note of the following:
 - The ``--chain`` argument is constant ``calamari-dev``, it must match the one we used to launch the network in the first place.
 - The ``--parachain-id`` argument is a constant ``7777``, which is the id we used when we registered it on the relay chain.
 - There are two ``--bootnodes`` constant arguments, one for the parachain node and one for the relay chain node.
-- The ``--collator`` argument. It can be changed to ``--validator`` to become a validator or removed in order to become a full node.
+
+#### Stay tuned for updates about joining the network as a Collator, as well as the incentives associated with that.


### PR DESCRIPTION
* Made the ``Join the network`` page refer to full nodes instead of Collators.
* Embedded all hyperlinks
* Corrected ``test-net`` to ``testnet``