### PR TITLE
doc fix: correct certbot argument for collator setup instructions

### DIFF
--- a/docs/collator/SetupAndRun.md
+++ b/docs/collator/SetupAndRun.md
@@ -270,6 +270,8 @@ the example below assumes:
 - your nodes hostname is **bob**
 - your calamari node uses default ports
 - your internet gateway (router) port forwards 443/ssl traffic arriving on the routers wan interface to your collator node
+- you have certbot installed, ideally as a snap ([instructions](https://certbot.eff.org/instructions))
+- you have version 2.3.1 or later of [certbot-dns-cloudflare](https://certbot-dns-cloudflare.readthedocs.io/en/stable/) installed ([instructions](https://snapcraft.io/certbot-dns-cloudflare))
 
 set up ssl port forwarding
 
@@ -279,7 +281,7 @@ set up ssl port forwarding
   
   sudo certbot certonly \
     --dns-cloudflare \
-    -dns-cloudflare-credentials .cloudflare-credentials \
+    --dns-cloudflare-credentials .cloudflare-credentials \
     -d bob.example.com \
     -d calamari.metrics.bob.example.com \
     -d kusama.metrics.bob.example.com


### PR DESCRIPTION
In late 2020 certbot stopped updating the apt package version of certbot for Ubuntu and switched entirely to packaging and distributing certbot as a snap package. Therefore the default installation of certbot on Ubuntu 20.04, together with the apt package certbot-dns-cloudflare are unfortunately too old to use restricted API tokens, and thus require a global API key, which poses a heightened security risk.

This PR explicitly advises collator installers to use snap installations of certbot and certbot-dns-cloudflare in order that a restricted cloudflare API token can be used for issuing a certificate. It also fixes an error in one of the arguments of the certbot command.