### PR TITLE
Specify absolute path for --dns-cloudflare-credentials

### DIFF
--- a/docs/collator/SetupAndRun.md
+++ b/docs/collator/SetupAndRun.md
@@ -364,7 +364,7 @@ cloudflare and route53 examples follow. google `python3-certbot-dns-${your_dns_p
     
     sudo certbot certonly \
       --dns-cloudflare \
-      --dns-cloudflare-credentials .cloudflare-credentials \
+      --dns-cloudflare-credentials /etc/letsencrypt/.cloudflare-credentials \
       -d bob.example.com \
       -d calamari.metrics.bob.example.com \
       -d kusama.metrics.bob.example.com


### PR DESCRIPTION
My renewals failed, I think because when running from cron, there was a different working directory, so my `.cloudflare-credentials` file wasn't found.

I suspect the easiest way to avoid this problem is just specifying an absolute path rather than just the filename. This hopefully removes any doubt about which directory the file is located in.

My renewal failure looked like this:

```
root@Ubuntu-2004-focal-64-minimal ~ # tail -21 /var/log/letsencrypt/letsencrypt.log
certbot.errors.PluginError: File not found: .cloudflare-credentials

2022-06-05 16:33:22,337:DEBUG:certbot._internal.display.obj:Notifying user:
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
2022-06-05 16:33:22,338:ERROR:certbot._internal.renewal:All renewals failed. The following certificates could not be renewed:
2022-06-05 16:33:22,338:ERROR:certbot._internal.renewal:  /etc/letsencrypt/live/cj.kmapro.de/fullchain.pem (failure)
2022-06-05 16:33:22,338:DEBUG:certbot._internal.display.obj:Notifying user: - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
2022-06-05 16:33:22,338:DEBUG:certbot._internal.log:Exiting abnormally:
Traceback (most recent call last):
  File "/snap/certbot/2035/bin/certbot", line 8, in <module>
    sys.exit(main())
  File "/snap/certbot/2035/lib/python3.8/site-packages/certbot/main.py", line 19, in main
    return internal_main.main(cli_args)
  File "/snap/certbot/2035/lib/python3.8/site-packages/certbot/_internal/main.py", line 1744, in main
    return config.func(config, plugins)
  File "/snap/certbot/2035/lib/python3.8/site-packages/certbot/_internal/main.py", line 1630, in renew
    renewal.handle_renewal_request(config)
  File "/snap/certbot/2035/lib/python3.8/site-packages/certbot/_internal/renewal.py", line 510, in handle_renewal_request
    raise errors.Error(
certbot.errors.Error: 1 renew failure(s), 0 parse failure(s)
2022-06-05 16:33:22,338:ERROR:certbot._internal.log:1 renew failure(s), 0 parse failure(s)
root@Ubuntu-2004-focal-64-minimal ~ # pwd
/root
root@Ubuntu-2004-focal-64-minimal ~ # ls -l .cloudflare-credentials
-r-------- 1 root root 107 Mar  8 15:24 .cloudflare-credentials
root@Ubuntu-2004-focal-64-minimal ~ #
```

In my case, I had the `.cloudflare-credentials` file in my `/root` directory but various certbot docs seem to suggest that config is expected by default in `/etc/letsencrypt` unless a different config directory is explicitly specified, so I suspect that is where it was looking.