### PR TITLE
Validation Script Has a Bug

### DIFF
--- a/docs/collator/SetupAndRun/keys.md
+++ b/docs/collator/SetupAndRun/keys.md
@@ -163,7 +163,7 @@ Starting with v3.2.1 you must provide all 3 of the following keys, earlier revis
       -s \
       --header 'Content-Type: application/json;charset=utf-8' \
       --data @./check-${key}.json \
-      http://localhost:9133 | jq -r '.result == "true"')
+      http://localhost:9133 | jq -r '.result == true')
     echo "${key}: ${has_key}"
   done
   ```


### PR DESCRIPTION
The Validation Script, bool comparison on line 166 should not have quotes, as it causes the compare to fail. Misleading as it seemingly reveals that inserted keys do not match.

Signed-off-by: Jason2d2 <55815929+Jason2d2@users.noreply.github.com>