### PR TITLE
Split Roadmap to top-level entry and cleanup

### DIFF
--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -1,0 +1,3 @@
+# Manta & Calamari Network Roadmap
+
+You can find the up-to-date version of the project roadmap [here](https://mantanetwork.notion.site/3b1b61e0aee8484396d674f4653e0813?v=451a4ad2105d4f9cb35fb74680359c1d)

--- a/docs/calamari/MariPay.md
+++ b/docs/calamari/MariPay.md
@@ -1,1 +1,1 @@
-# MariPay
+# MantaPay on Calamari

--- a/docs/calamari/MariSwap.md
+++ b/docs/calamari/MariSwap.md
@@ -1,1 +1,0 @@
-# MariSwap

--- a/docs/calamari/Overview.md
+++ b/docs/calamari/Overview.md
@@ -10,9 +10,3 @@ Calamari is Manta Network's canary-net, an early, highly experimental version of
 In the early period, Calamari parachain will provide two products:
 
 **MariPay**: a token-agnostic private payment service. MariPay supports the private transfer of Kusama and its Parachain assets, including significant crypto assets supported on Kusama. Users can transact popular assets like stablecoins and wrapped BTC while simultaneously benefiting from on-chain privacy through ZKP.
-
-**MariSwap**: a private AMM-based DEX. MariSwap offers users the capability of swaps between parachain assets while preserving the privacy of the user. It also provides never-before-seen features in the industry, such as private liquidity pools.
-
-## Calamari Roadmap
-
-[RoadMap](https://emphasized-seed-161.notion.site/3b1b61e0aee8484396d674f4653e0813?v=451a4ad2105d4f9cb35fb74680359c1d)

--- a/docs/calamari/RunNode.md
+++ b/docs/calamari/RunNode.md
@@ -1,9 +1,4 @@
----
-sidebar_position: 7
-id: RunNode
-title: 🔌  Run a Calamari Node
----
-
+# 🔌  Run a Calamari Node
 To run a calamari full node, the easiest way is to use `docker`:
 
 ```bash

--- a/sidebars.js
+++ b/sidebars.js
@@ -16,6 +16,7 @@ module.exports = {
       label: 'What is Manta?',
       id:'Introduction',
     },
+    'Roadmap',
     {
       type: 'category',
       label: 'Concepts',


### PR DESCRIPTION
Roadmap link was broken.
Didn't matter because nobody would have found the roadmap link anyway

Signed-off-by: Adam Reif <Garandor@manta.network>