### PR TITLE
Trusted Setup Client v2 Guide Update

### DIFF
--- a/docs/guides/TrustedSetup.md
+++ b/docs/guides/TrustedSetup.md
@@ -92,7 +92,18 @@ manta-trusted-setup register
 (or the appropriate variant if you used the Windows or alternative Linux installation above).
 
 You will be asked for an email address and twitter account.  After providing them you will see output that looks something like this:
+
 ![registration prompt](./resources/ts_guide_register.png)
+
+
+<details>
+  <summary>(Drop down if your output looks different)</summary>
+    If you are using an old version of the client you may see a slightly different output, like this:
+
+  ![registration prompt v1](./resources/ts_guide_register_v1.png)
+    You can either update to the newest client (uninstall/reinstall) or enter these details manually in this [Registration form](https://mantanetwork.typeform.com/TrustedSetup). Make sure you copy each field exactly as it appears on screen.
+
+</details>
 
 2. **Registration Form**: Copy the information from the previous step into this [Registration form](https://mantanetwork.typeform.com/TrustedSetup).  Do NOT include the secret phrase. It is important that you use the same Twitter handle and email address as above, since otherwise the signature will be invalid.
 

--- a/docs/guides/resources/ts_guide_register.png
+++ b/docs/guides/resources/ts_guide_register.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d9e8c377f0afed1b365a46f7509242676ca07edfd522407d4259efca5f74f1a
-size 194289
+oid sha256:8ee0092876e734b83959b8f95d8ec2a3d57df2d012d76ac0274afaa15ba032e4
+size 196590

--- a/docs/guides/resources/ts_guide_register_v1.png
+++ b/docs/guides/resources/ts_guide_register_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d9e8c377f0afed1b365a46f7509242676ca07edfd522407d4259efca5f74f1a
+size 194289


### PR DESCRIPTION
Updates the trusted setup guide to reflect the changes made to the client.

The main change is that users no longer manually enter their cryptographic signature in the registration form. Instead it is embedded in a link. We hope this will reduce the rate of invalid registrations.