### PR TITLE
Staking Doc Fixes

### DIFF
--- a/docs/calamari/KMA/04-TokenDistribution.md
+++ b/docs/calamari/KMA/04-TokenDistribution.md
@@ -5,7 +5,7 @@
 | Name                 |         Amount | Distribution                                             | Lockup                                                                                          |
 |----------------------|---------------:|----------------------------------------------------------|-------------------------------------------------------------------------------------------------|
 | Community Rewards    |  2,000,000,000 | Airdrop, liquidity incentives                            | Continuously adjusted emission for 4 years total                                                |
-| Parachain Crowdloans | ~2,400,000,000 | Parachain Crowdloan Participants                         | 100% Locked at TGE, used over 4 years/crowdloans                                                |
+| Parachain Crowdloan | ~2,400,000,000 | Parachain Crowdloan Participants                         | 100% Locked at TGE, used over the first year                                                    |
 | Development Fund     | ~2,200,000,000 | Network adoption, grants programs, ecosystem development | 100% Locked at TGE, controlled by governance                                                    |
 | MANTA Lockdrop       |  2,000,000,000 | Manta Holders                                            | 100% Locked at TGE, vesting starts when Manta token launches and gradually unlocks over 4 years |
 | Staking rewards      |    900,000,000 | Stakers(Collators & Delegators)                          | 100% Locked at TGE, distribution starts with staking launch, lasts for 3 years                  |
@@ -15,8 +15,8 @@
 20% of KMA is reserved for liquidity incentives and airdrops to early community members. Liquidity mining rewards are continuously adjusted based on currently available liquidity, if liquidity is good, additional incentivization will be small.
 This reserve will be released over 4 years after TGE.
 
-## Parachain Crowdloans
-~24% of this allocation has already been distributed as rewards to the initial  ~16,000 participants of the first crowdloan, 45% of which was released to crowdloan participants at TGE. The remaining 66% were vested linearly with releases every 8 weeks until August 17th 2022, where vesting for the first crowdloan finished. 30% was planned to incentivize the first crowdloan, the left-over 6% will be distributed to the development fund. 
+## Parachain Crowdloan
+~24% were distributed as rewards to the initial ~16,000 participants of the first crowdloan, 45% of which was released to crowdloan participants at TGE. The remaining 55% were vested linearly with releases every 8 weeks until August 17th 2022, where vesting for the first crowdloan finished. Originally this allocation was planned to be 30% of initial issuance. The left-over 6% will be distributed to the development fund. 
 
 ## Development Fund
 ~22% KMA are reserved for development funds to support network adoption and increase activity through grants programs and developer support on the Calamari network, which will be determined by the on-chain governance. 

--- a/docs/calamari/Staking/06-Collation/03-SetupAndRun/05-keys.md
+++ b/docs/calamari/Staking/06-Collation/03-SetupAndRun/05-keys.md
@@ -113,7 +113,7 @@ This command demonstrates a session key insertion using a key created with
       http://localhost:9133
   done
   ```
-- **Validation**: Check that the session keys stored in the node match the generated ones
+- **Validation**: Check that the session keys stored in the node match the generated ones (below command returns a `"result":true` field)
   ```bash
   #!/bin/bash
   for key in nmbs rand; do
@@ -121,7 +121,7 @@ This command demonstrates a session key insertion using a key created with
       -s \
       --header 'Content-Type: application/json;charset=utf-8' \
       --data @./check-${key}.json \
-      http://localhost:9133 | jq -r '.result == "true"')
+      http://localhost:9133 )
     echo "${key}: ${has_key}"
   done
   ```

--- a/docs/calamari/Staking/06-Collation/03-SetupAndRun/05-keys.md
+++ b/docs/calamari/Staking/06-Collation/03-SetupAndRun/05-keys.md
@@ -189,9 +189,9 @@ Although the screenshot shows a connected dolphin node, the procedure is identic
    - In the first box, labelled "using the selected account", select the collator account holding the [collator KMA bond](../Requirements#kma-bond).
    - In the second (dropdown) box labelled "submit the following extrinsic", select `session`.
    - In the third (dropdown) box, select `setKeys(keys, proof)`
-   - In the fourth box labelled `aura: SpConsensusAuraSr25519AppSr25519Public`, enter the hex public key of the Aura session key you generated earlier.
+   - In the fourth box labelled `aura: SpConsensusAuraSr25519AppSr25519Public`, enter the hex public key of the Aura session key you generated earlier or a dummy value, e.g. `0x0000000000000000000000000000000000000000000000000000000000000000`
 :::note
-`aura` is an inactive key from pre-v3.3.0 versions of the node. The value you provide here will not be used and you may provide a dummy value e.g. `0x0000000000000000000000000000000000000000000000000000000000000000` or the key obtained from `rotateKeys` above
+`aura` is an inactive key from pre-v3.3.0 versions of the node. The value you provide here will not be used
 :::
    - In the fifth box, labelled `nimbus: NimbusPrimitivesNimbusCryptoPublic`, enter the hex public key of the Nimbus session key you generated earlier.
    - In the sixth box, labelled `vrf: SessionKeyPrimitivesVrfVrfCryptoPublic`, enter the hex public key of the VRF session key you generated earlier.


### PR DESCRIPTION
- Fix tokenomics typos
- Note `aura` key is obsolete  in `SessionKeys` page of collator docs
- don't do jq for hasKey result filtering, that's led to confusion in the past

Signed-off-by: Adam Reif <Garandor@manta.network>