### PR TITLE
Add Envio to Data Indexers

### DIFF
--- a/docs/manta-pacific/Tools/Data Indexers.md
+++ b/docs/manta-pacific/Tools/Data Indexers.md
@@ -1,5 +1,23 @@
 # Data Indexers
 
+## Envio
+
+[Index Manta Pacific with Envio](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=manta&utm_medium=partner-docs)
+
+### Overview
+
+Envio is a high-performance indexing framework that turns Manta Pacific smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. On Manta Pacific, HyperIndex is powered by HyperSync for historical syncs up to 2000x faster than traditional RPC. HyperIndex supports real-time and historical data with reorg support, event handlers in TypeScript, JavaScript, or ReScript, and multichain data aggregation across EVM and non-EVM networks.
+
+### Getting started
+
+To get started, auto-generate an indexer from any verified contract:
+
+```bash
+pnpx envio init
+```
+
+Write your event handlers, then run locally or deploy to [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service?utm_source=manta&utm_medium=partner-docs) for fully managed hosting. Manta Pacific is available on HyperSync at `https://manta.hypersync.xyz`. Follow the [quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=manta&utm_medium=partner-docs) for full setup instructions.
+
 ## Goldsky
 
 [​Index Manta Pacific with Goldsky](https://docs.goldsky.com/chains/manta#overview)

--- a/docs/manta-pacific/Tools/Data Indexers.md
+++ b/docs/manta-pacific/Tools/Data Indexers.md
@@ -18,6 +18,8 @@ pnpx envio init
 
 Write your event handlers, then run locally or deploy to [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service?utm_source=manta&utm_medium=partner-docs) for fully managed hosting. Manta Pacific is available on HyperSync at `https://manta.hypersync.xyz`. Follow the [quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=manta&utm_medium=partner-docs) for full setup instructions.
 
+See Envio's [performance benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=manta&utm_medium=partner-docs).
+
 ## Goldsky
 
 [​Index Manta Pacific with Goldsky](https://docs.goldsky.com/chains/manta#overview)

--- a/docs/manta-pacific/Tools/Data Indexers.md
+++ b/docs/manta-pacific/Tools/Data Indexers.md
@@ -2,7 +2,7 @@
 
 ## Envio
 
-[Index Manta Pacific with Envio](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=manta&utm_medium=partner-docs)
+[Index Manta Pacific with Envio](https://envio.dev/?utm_source=manta&utm_medium=partner-docs)
 
 ### Overview
 

--- a/docs/manta-pacific/Tools/Data Indexers.md
+++ b/docs/manta-pacific/Tools/Data Indexers.md
@@ -6,7 +6,7 @@
 
 ### Overview
 
-Envio is a high-performance indexing framework that turns Manta Pacific smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. On Manta Pacific, HyperIndex is powered by HyperSync for historical syncs up to 2000x faster than traditional RPC. HyperIndex supports real-time and historical data with reorg support, event handlers in TypeScript, JavaScript, or ReScript, and multichain data aggregation across EVM and non-EVM networks.
+Envio is the data layer for blockchain apps. It gives Manta Pacific developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud. On Manta Pacific, HyperIndex is powered by HyperSync for historical syncs up to 2000x faster than traditional RPC. HyperIndex supports real-time and historical data with reorg support, event handlers in TypeScript, JavaScript, or ReScript, and multichain data aggregation across EVM and non-EVM networks.
 
 ### Getting started
 


### PR DESCRIPTION
Adds Envio to the Data Indexers page for Manta Pacific, matching the existing entry format.

Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. On Manta Pacific it is powered by HyperSync for fast historical syncs.

- Website: https://envio.dev/
- Docs: https://docs.envio.dev/
- HyperIndex overview: https://docs.envio.dev/docs/HyperIndex/overview